### PR TITLE
Allow package to be specified for test mode

### DIFF
--- a/lib/guard/go.rb
+++ b/lib/guard/go.rb
@@ -4,9 +4,9 @@ require 'guard/watcher'
 require 'guard/go/runner'
 
 module Guard
-  class Go < ::Guard::Guard 
+  class Go < ::Guard::Guard
     attr_reader :options
-    
+
     def initialize(watchers = [], options = {})
       super
 
@@ -15,7 +15,7 @@ module Guard
         :test => false,
         :args => []
       }
-      
+
       @options = defaults.merge(options)
       @options[:args] = wrap_args(@options[:args])
       @options[:args_to_s] = @options[:args].join(" ")
@@ -43,6 +43,8 @@ module Guard
     def start_info
       if @options[:test]
         UI.info "Running go test..."
+      elsif @options[:doc]
+        UI.info "Running go doc: #{@runner.build_go_command}"
       else
         UI.info "Running #{options[:server] } #{options[:args_to_s]} ..."
       end
@@ -51,7 +53,7 @@ module Guard
     def run_info(pid)
       return if @options[:test]
       if pid
-        UI.info "Started Go app, pid #{pid}"  
+        UI.info "Started Go app, pid #{pid}"
       else
         UI.info "Go command failed, check your log files."
       end

--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -6,7 +6,7 @@ module Guard
 
     def initialize(options)
       @options = options
-      raise ArgumentError, "Server file not found. Check the :server option in your Guardfile." unless server_file_exists? or @options[:test]
+      raise ArgumentError, "Server file not found. Check the :server option in your Guardfile." unless server_file_exists? or @options[:test] or @options[:doc]
     end
 
     def start
@@ -30,6 +30,8 @@ module Guard
     def build_go_command
       if @options[:test]
         %{cd #{Dir.pwd} && go test #{@options[:package]}}
+      elsif @options[:doc]
+        %{cd #{Dir.pwd} && godoc #{@options[:args].join(' ')}}
       else
         %{cd #{Dir.pwd} && go run #{@options[:server]} #{@options[:args_to_s]} &}
       end

--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -6,8 +6,7 @@ module Guard
 
     def initialize(options)
       @options = options
-
-      raise "Server file not found. Check your :server option in your Guarfile." unless File.exists? @options[:server]
+      raise ArgumentError, "Server file not found. Check the :server option in your Guardfile." unless server_file_exists? or @options[:test]
     end
 
     def start
@@ -30,7 +29,7 @@ module Guard
 
     def build_go_command
       if @options[:test]
-        %{cd #{Dir.pwd} && go test}
+        %{cd #{Dir.pwd} && go test #{@options[:package]}}
       else
         %{cd #{Dir.pwd} && go run #{@options[:server]} #{@options[:args_to_s]} &}
       end
@@ -45,9 +44,14 @@ module Guard
     end
 
     private
+
     def run_go_command!
       system build_go_command
       @pid = $?.pid
+    end
+
+    def server_file_exists?
+      File.exists? @options[:server]
     end
   end
 end


### PR DESCRIPTION
This change allows the following stanza:

``` ruby
guard 'go', :test => true, :package => 'auth/config' do
  watch(%r{src/auth/config/.*_test\.go$})
end
```

which will run

```
go test auth/config
```
