### PR TITLE
Change compute of pid in ruby to direct call to killall.

### DIFF
--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -15,12 +15,7 @@ module Guard
     end
 
     def stop
-      ps_go_pid.each do |pid|
-        system %{kill -KILL #{pid}}
-      end
-      while ps_go_pid.count > 0
-        sleep sleep_time
-      end
+      system 'killall a.out'
     end
 
     def restart


### PR DESCRIPTION
Currently you are trying to kill all pids that have a.out as their name. You do this using ps, awk and kill. This can be simplified by calling 'killall a.out' which is a standard unix/osx command that takes a name and kills things that have that name.
