### PR TITLE
absent a.out

### DIFF
--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -7,7 +7,7 @@ module Guard
     def initialize(options)
       @options = options
 
-      raise "Server file not found. Check your :server option in your Guarfile." unless File.exists? @options[:server]
+      raise "Server file not found. Check your :server option in your Guardfile." unless File.exists? @options[:server]
     end
 
     def start
@@ -37,7 +37,8 @@ module Guard
     end
 
     def ps_go_pid
-      `ps aux | awk '/a.out/&&!/awk/{print $2;}'`.split("\n").map { |pid| pid.to_i }
+      server_file_name_first_part = @options[:server].split('.')[0]
+      `ps aux | awk '/#{server_file_name_first_part}/&&!/awk/{print $2;}'`.split("\n").map { |pid| pid.to_i }
     end
 
     def sleep_time


### PR DESCRIPTION
The process finding command didn't work for me so I ended up with the old process blocking the port for the new one. This fix makes it work but it finds a bit too many processes most of the time (the shell one that starts the go one - for example) and fails to kill them when they get killed implicitly. I don't know enough about things like this to make sure it works flawlessly. 

I'm on OS X 10.8.3.
