### PR TITLE
Use childprocess and sys-proctables gems for more robust starting/stopping

### DIFF
--- a/guard-go.gemspec
+++ b/guard-go.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::GoVersion::VERSION
 
   gem.add_dependency 'guard', '>= 1.0.0'
+  gem.add_dependency 'sys-proctable', '>= 0.9'
+  gem.add_dependency 'childprocess', '>= 0.3'
 end


### PR DESCRIPTION
The idea is to let the `childprocess` and `sys-proctables` gems do the heavy lifting when it comes to starting process and figuring out which process to kill on stop. I'm running go1.2, but I'm assuming that go1.0/go1.1 still have the relevant process (whether it be `a.out` or the new naming convention) as a child of the `go run` command.
