### PR TITLE
Support `go build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Edit this and configure your application file name and desired options.
 
 Options defaults to:
 
-    :server => 'app.go' # Go source file to run
-    :test   => false    # To run go test insted of the app.
-    :args   => []       # Parameters, e.g. :args => 420, :args => [420, 120], :args => ["one", "two"]
+    :server      => 'app.go' # Go source file to run
+    :test        => false    # To run go test instead of the app.
+    :build_only  => false    # To build instead of run.
+    :args        => []       # Parameters, e.g. :args => 420, :args => [420, 120], :args => ["one", "two"]
 
     $ bundle exec guard

--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -45,7 +45,11 @@ module Guard
       if @options[:test]
         @proc = ChildProcess.build("go", "test")
       else
-        @proc = ChildProcess.build("go", "run", @options[:server], @options[:args_to_s])
+        if @options[:build_only]
+          @proc = ChildProcess.build("go", "build")
+        else
+          @proc = ChildProcess.build("go", "run", @options[:server], @options[:args_to_s])
+        end
       end
 
       @proc.io.inherit!


### PR DESCRIPTION
This adds an option: `:build_only`, to run `go build` instead of `go run`. 

Use case: I want to build my app and see if there are any pending issues (syntax errors, unused variables and imports, etc.), but I don't want to run the app on every run.

Usage (README has been updated as well):

``` ruby
guard 'go', server: 'app.go', build_only: true do
  watch(%r{\.go$})
end
```
