### PR TITLE
Kernel.exec ignores second args if string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Options defaults to:
     :server      => 'app.go' # Go source file to run
     :test        => false    # To run go test instead of the app.
     :build_only  => false    # To build instead of run.
-    :args        => []       # Parameters, e.g. :args => 420, :args => [420, 120], :args => ["one", "two"]
+    :args        => []       # Parameters, e.g. :args => 420, :args => [420, 120], :args => ["--one", 420, "--two", 120]
     :cmd         => 'go'     # Name of the Go commandline tool
 
     $ bundle exec guard

--- a/lib/guard/go/runner.rb
+++ b/lib/guard/go/runner.rb
@@ -56,7 +56,8 @@ module Guard
 
       @proc.wait
       server_cmd = "./" + @options[:server].sub('.go', '')
-      @proc = ChildProcess.build server_cmd, options[:args_to_s]
+      args = [server_cmd, options[:args]].flatten
+      @proc = ChildProcess.build  *args
       start_child_process!
     end
 


### PR DESCRIPTION
This pull request resolves an issue on Ubuntu 16.04 when using multiple args/flags with values. I followed the behavior through the childprocess gem to Ruby's 2.4.1 Kernel.exec method.

When multiple arguments and values combined into a string is passed to Kernel.exec the application receives only one argument, which can not be parsed. This behavior could change based on the platform .e.g. Linux, Windows, OS X.

This pull request keeps the arguments separated as suggested in the ruby documentation.
